### PR TITLE
Legg til ukentlig Dependabot + Copilot-oppdateringsoppsett

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: monday
+      time: "07:00"
+      timezone: Europe/Oslo
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3

--- a/.github/prompts/oppdateringer.prompt.md
+++ b/.github/prompts/oppdateringer.prompt.md
@@ -1,0 +1,131 @@
+---
+name: ukentlige-oppdateringer
+description: Kjør ukentlige Dependabot-oppdateringer for GitHub Actions-workflows i dette repoet
+---
+
+Du er en agent som utfører ukentlige oppdateringer av GitHub Actions-workflows for dette repoet. Dependabot har allerede åpnet PRer — din jobb er å samle dem på én branch og klargjøre for merge.
+
+
+## Kontekst om repoet
+
+- **Dependabot-konfigurert for**: GitHub Actions-workflows (`.github/workflows/`)
+- **Ingen package manager** — kun workflow-filer oppdateres
+- **CI/CD**: Deploy til dev skjer via `workflow_dispatch`
+
+
+## Steg 1 — Finn ukenummer og opprett branch
+
+```bash
+WEEK=$(date +%V)
+YEAR=$(date +%Y)
+BRANCH="oppdateringer/uke-${WEEK}-${YEAR}"
+git checkout main
+git pull origin main
+git checkout -b "$BRANCH"
+echo "Branch opprettet: $BRANCH"
+```
+
+
+## Steg 2 — Hent og verifiser åpne Dependabot-PRer
+
+```bash
+gh pr list --author "app/dependabot" --state open --json number,title,headRefName,labels,author
+```
+
+### ⚠️ Sikkerhetssjekk før merge
+
+**Verifiser for hver PR at:**
+1. `author.login` er nøyaktig `app/dependabot`
+2. Branch-navnet følger mønsteret `dependabot/github-actions/<action-navn>`
+3. Endringer er begrenset til filer under `.github/workflows/`
+
+```bash
+gh pr view <nr> --json author,headRefName,files \
+  | jq '{author: .author.login, branch: .headRefName, files: [.files[].path]}'
+```
+
+**Ikke merge PRer som:**
+- Har en annen avsender enn `app/dependabot`
+- Inneholder endringer utenfor `.github/workflows/`
+
+### ⚠️ Major-versjonshopp i actions — les release notes
+
+Dersom en PR bumper en action til en **ny major-versjon** (f.eks. `actions/checkout@v3` → `v4`):
+
+```bash
+# Les release notes for actionen
+gh pr view <nr> --json body | jq -r '.body' | head -100
+```
+
+**Sjekk spesielt:**
+- Er det endringer i inputs/outputs?
+- Krever actionen ny versjon av runner-OS eller annen konfigurasjon?
+- Er det `breaking`-endringer som påvirker eksisterende workflow-konfigurasjon?
+
+### Prioriter sikkerhets-PRer
+
+```bash
+gh pr list --author "app/dependabot" --state open --json number,title,labels \
+  | jq '.[] | select(.labels[].name | test("security"))'
+```
+
+
+## Steg 3 — Merge PRer
+
+For hver PR:
+
+```bash
+git fetch origin <dependabot-branch>
+git merge origin/<dependabot-branch> --no-edit
+```
+
+Ingen bygg/test-steg er nødvendig for rene workflow-oppdateringer.
+
+### Revertering
+
+```bash
+git revert HEAD --no-edit
+```
+
+
+## Steg 4 — Push og lag PR
+
+```bash
+git push origin "$BRANCH"
+
+gh pr create \
+  --title "Ukentlige oppdateringer uke ${WEEK}" \
+  --body "$(cat <<'EOF'
+## Ukentlige GitHub Actions-oppdateringer
+
+Denne PRen samler alle Dependabot-oppdateringer av GitHub Actions for uken.
+
+### Inkluderte oppdateringer
+<!-- Liste over oppdaterte actions med versjoner -->
+
+### Skippet oppdateringer
+<!-- PRer som ikke ble inkludert, med begrunnelse -->
+
+### Verifisering
+- [ ] CI-bygg er grønt etter merge
+
+Merge til `main` etter godkjenning.
+EOF
+)" \
+  --base main \
+  --head "$BRANCH"
+```
+
+
+## Steg 5 — Instruksjon til mennesket
+
+```
+✅ Branch klar: oppdateringer/uke-<uke-nr>-<år>
+
+Neste steg:
+1. Gjennomgå PR-en
+2. Godkjenn og merge mot main
+
+Merget i denne runden:
+<liste over actions som ble oppdatert>
+```

--- a/.github/workflows/ukentlige-oppdateringer.yml
+++ b/.github/workflows/ukentlige-oppdateringer.yml
@@ -16,14 +16,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
-      contents: read  # Nødvendig for actions/checkout
-      issues: write   # Nødvendig for gh issue create
+      contents: write        # Nødvendig for å slette gamle branches
+      issues: write          # Nødvendig for gh issue create
+      pull-requests: write   # Nødvendig for å lukke gamle PRer
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Lukk gammel oppdaterings-PR om den finnes
+        run: |
+          OLD_PRS=$(gh pr list \
+            --state open \
+            --json number,title \
+            --jq '.[] | select(.title | test("Ukentlige oppdateringer uke")) | .number')
+
+          for PR_NUM in $OLD_PRS; do
+            echo "Lukker gammel PR #${PR_NUM}"
+            gh pr close "$PR_NUM" \
+              --comment "Lukkes automatisk — ny ukentlig oppdatering starter nå." \
+              --delete-branch || true
+          done
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sørg for at 'dependencies'-label finnes
         run: |

--- a/.github/workflows/ukentlige-oppdateringer.yml
+++ b/.github/workflows/ukentlige-oppdateringer.yml
@@ -1,0 +1,47 @@
+name: Ukentlige oppdateringer
+
+on:
+  schedule:
+    - cron: '0 7 * * 1' # Hver mandag kl. 07:00 UTC
+  workflow_dispatch:     # Kan også kjøres manuelt fra Actions-fanen
+
+# Hindrer parallelle kjøringer — unngår duplikat-issues
+concurrency:
+  group: ukentlige-oppdateringer
+  cancel-in-progress: false
+
+jobs:
+  opprett-issue:
+    name: Opprett oppdaterings-issue
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read  # Nødvendig for actions/checkout
+      issues: write   # Nødvendig for gh issue create
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Sørg for at 'dependencies'-label finnes
+        run: |
+          gh label create "dependencies" \
+            --color "0075ca" \
+            --description "Dependency updates" 2>/dev/null || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Opprett issue og tildel Copilot
+        run: |
+          WEEK=$(date +%V)
+          YEAR=$(date +%Y)
+
+          gh issue create \
+            --title "Ukentlige oppdateringer uke ${WEEK} (${YEAR})" \
+            --body-file .github/prompts/oppdateringer.prompt.md \
+            --assignee "@copilot" \
+            --label "dependencies"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ukentlige-oppdateringer.yml
+++ b/.github/workflows/ukentlige-oppdateringer.yml
@@ -2,7 +2,7 @@ name: Ukentlige oppdateringer
 
 on:
   schedule:
-    - cron: '0 7 * * 1' # Hver mandag kl. 07:00 UTC
+    - cron: '0 10 * * 1' # Hver mandag kl. 10:00 UTC (etter at Dependabot har kjørt kl. 07:00)
   workflow_dispatch:     # Kan også kjøres manuelt fra Actions-fanen
 
 # Hindrer parallelle kjøringer — unngår duplikat-issues


### PR DESCRIPTION
## Ukentlig oppdateringsoppsett med GitHub Copilot

Setter opp samme opplegg som team paw har i `paw-brukerstotte`: en GitHub Actions-workflow oppretter automatisk et issue hver mandag kl. 07:00 (norsk tid), tildelt `@copilot`, med en detaljert instruksjonsprompt for å samle og merge Dependabot-PRer.

### Filer lagt til

- `.github/workflows/ukentlige-oppdateringer.yml` — kjøres hver mandag, oppretter issue med prompt som body
- `.github/prompts/oppdateringer.prompt.md` — detaljert instruksjon til Copilot om hvordan samle og merge Dependabot-PRer, inkl. sikkerhetssjekk, sorteringsrekkefølge og migreringsguider ved major-versjonshopp
- `.github/dependabot.yml` — (kun nye repos) konfigurerer Dependabot med ukentlig schedule

### Slik fungerer det

1. Workflow kjøres automatisk hver mandag, eller manuelt fra Actions-fanen
2. Et GitHub Issue opprettes med tittelen "Ukentlige oppdateringer uke XX (YYYY)"
3. Issuen tildeles `@copilot` som leser prompten og utfører oppdateringene:
   - Oppretter en `oppdateringer/uke-XX-YYYY`-branch
   - Merger alle åpne Dependabot-PRer med testing mellom hvert steg
   - Sjekker migreringsguider ved major-versjonshopp
   - Oppretter en PR mot `main` for menneskelig gjennomgang og merge